### PR TITLE
Included CALDAV_PORT in argument passed to CalDAVClient constructor

### DIFF
--- a/backend/caldav.php
+++ b/backend/caldav.php
@@ -31,7 +31,7 @@ class BackendCalDAV extends BackendDiff {
 	{
 		$this->_username = $username;
 		$this->_caldav_path = str_replace('%u', $username, CALDAV_PATH);
-		$this->_caldav = new CalDAVClient(CALDAV_SERVER . $this->_caldav_path, $username, $password);
+		$this->_caldav = new CalDAVClient(CALDAV_SERVER . ":" . CALDAV_PORT . $this->_caldav_path, $username, $password);
 		$options = $this->_caldav->DoOptionsRequest();
 		if (isset($options["PROPFIND"]))
 		{


### PR DESCRIPTION
I set a non-standard port for SSL on my CalDAV server, but the value I set in config.php file was not being passed through.  
